### PR TITLE
Switch to http2 to improve http speed

### DIFF
--- a/remote_files/nginx.conf
+++ b/remote_files/nginx.conf
@@ -1,16 +1,35 @@
 server {
     listen 80;
     server_name zerodt.live www.zerodt.live;
+    return 301 https://$host$request_uri;
+}
 
+server {
+    listen 443 ssl http2;
+    server_name zerodt.live www.zerodt.live;
+
+    # SSL Certificates (managed by Certbot)
+    ssl_certificate /etc/letsencrypt/live/zerodt.live/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/zerodt.live/privkey.pem;
+
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    # Frontend (localhost:3000)
     location / {
         proxy_pass http://localhost:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Backend API (localhost:7070)
     location /api/ {
         proxy_pass http://localhost:7070;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
HTTP/2 is the current industry standard. It allows "multiplexing," meaning the browser can download your CSS, JS, and images all at once over a single connection, rather than waiting in line.