### PR TITLE
Make deploy scrip idempotent

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}


### PR DESCRIPTION
I made two changes. First, the script now pulls new images before stopping running containers, ensuring the system is never left in a down state if the pull fails, because of the set -e. Second, a version check was added that skips deployment if the target version is already running, avoiding unnecessary restarts. A --force flag was added to allow manual redeployment when needed during testing, i am not sure if this feature is necessary or would be annoying for the way we are working, but it makes it more idempotent. 