### PR TITLE
Mathias idempotent2

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -46,7 +46,7 @@ sudo systemctl start docker
 sudo systemctl enable docker
 
 # EXTRA CHECK TO SEE IF THAT ENV FILE IS THERE (I PRAY)
-if [ ! -f /minitwit.env ]; then 
+if [ ! -f /minitwit/.env ]; then 
     echo "Missing environment file. Copy it brother just as written in the ".env.template" file"
     exit 1
 fi


### PR DESCRIPTION
Step 1 - Install doctl
Wrapped the doctl download and install in a check: if ! command -v doctl only downloads and installs doctl if it's not already installed. The export, DROPLET_ID, and doctl assign commands still run every time since they configure the current session.

Step 2 - Mounting
Added mountpoint -q check before the mount command so it only mounts the volume if it's not already mounted. Added grep -q check before the fstab entry so it only appends the line if it's not already in the file. Without these checks, mounting would fail on re-runs and fstab would get duplicate entries.

Step 3 - SSH Keys
Changed all SSH key lines from plain echo >> file to grep -q "unique_id" file || echo "key" >> file. This checks if the key already exists before appending. Uses the unique identifier at the end of each key (e.g. mono@monolith, jbul@itu.dk) to search. Same fix applied to the bashrc line (cd /minitwit).
APT lock handling
Changed sudo killall apt apt-get to sudo killall apt apt-get 2>/dev/null || true so it doesn't fail when no apt processes are running. 2>/dev/null hides the error message, || true ensures the script continues.
Changed sudo rm to sudo rm -f for the lock file so it doesn't fail if the file doesn't exist. -f means force — silently succeeds even if there's nothing to remove.

Step 4 - Nginx HTTP config
Wrapped the cp command in if [ ! -f /minitwit/nginx.conf ] so it only copies the HTTP config if nginx.conf doesn't already exist. This prevents overwriting a working SSL config with the HTTP config on re-runs.

Step 7 - Nginx SSL config
Added a check (if [ -f fullchain.pem ]) so it only swaps to SSL config and reloads nginx if certificates actually exist. Without this, it would try to use SSL config without certs and nginx would fail.