### PR TITLE
Time fixes

### DIFF
--- a/minitwit-java/src/main/java/zerodowntime/util/FormatUtils.java
+++ b/minitwit-java/src/main/java/zerodowntime/util/FormatUtils.java
@@ -4,14 +4,14 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 public class FormatUtils {
 
     public static String formatDatetime(long timestamp) {
         return Instant.ofEpochSecond(timestamp)
-                .atZone(ZoneOffset.UTC)
+                .atZone(ZoneId.of("Europe/Copenhagen"))
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd @ HH:mm"));
     }
 

--- a/monitoring/prometheus/Dockerfile
+++ b/monitoring/prometheus/Dockerfile
@@ -1,2 +1,5 @@
 FROM prom/prometheus:latest
 COPY prometheus.yml /etc/prometheus/prometheus.yml
+
+# Without this line, prometheus deletes data after 15 days
+CMD ["--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.retention.time=90d"]

--- a/remote_files/docker-compose.yml
+++ b/remote_files/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - JDBC_USER=${POSTGRES_USER}
       - JDBC_PASS=${POSTGRES_PASSWORD}
       - JAVA_TOOL_OPTIONS=-Djdk.tracePinnedThreads=full
+      - TZ=Europe/Copenhagen # Otherwise log timestaps 1 hour behind (UTC)
     depends_on:
       postgres-db:
         condition: service_healthy


### PR DESCRIPTION
fix logs and messages being an hour behind our time (cph vs UTC).
Retain prometheus data longer