### PR TITLE
rework queries to use indexes better

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -24,7 +24,7 @@ resource "digitalocean_droplet" "swarm_node" {
 resource "digitalocean_droplet" "db" {
   name     = "minitwit-db"
   image    = "ubuntu-24-04-x64"
-  size     = "s-1vcpu-1gb"
+  size     = "s-1vcpu-2gb"
   region   = "fra1"
   ssh_keys = [var.ssh_key_fingerprint]
   tags   = ["db"]

--- a/minitwit-java/src/main/java/zerodowntime/controller/web/UserController.java
+++ b/minitwit-java/src/main/java/zerodowntime/controller/web/UserController.java
@@ -57,6 +57,11 @@ public class UserController extends BaseController {
             return;
         }
 
+        if (userIdToFollow.equals(userId)) {
+            ctx.status(400);
+            return;
+        }
+
         boolean followed = userService.followUser(userId, userIdToFollow);
 
         ctx.status(followed ? 204 : 200);

--- a/minitwit-java/src/main/java/zerodowntime/repository/MessageRepository.java
+++ b/minitwit-java/src/main/java/zerodowntime/repository/MessageRepository.java
@@ -85,9 +85,17 @@ public class MessageRepository extends BaseRepository {
     }
 
     public int getPublicTimelineCount() {
-        return db.resultQuery("SELECT reltuples::bigint FROM pg_class WHERE relname = 'message'")
-                .fetchOne()
-                .get(0, Integer.class);
+        try {
+            return db.resultQuery("SELECT reltuples::bigint FROM pg_class WHERE relname = 'message'")
+                    .fetchOne()
+                    .get(0, Integer.class);
+        } catch (Exception e) { // this is for the test H2 database. It doesn't have the pg_class, so needs this
+                                // fix.
+            return db.selectCount()
+                    .from(MESSAGE)
+                    .where(MESSAGE.FLAGGED.eq(0))
+                    .fetchOne(0, int.class);
+        }
     }
 
     public List<MessageDto> getMessagesByUserId(int userId, int limit, int offset) {

--- a/minitwit-java/src/main/java/zerodowntime/repository/MessageRepository.java
+++ b/minitwit-java/src/main/java/zerodowntime/repository/MessageRepository.java
@@ -1,6 +1,8 @@
 package zerodowntime.repository;
 
 import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+
 import zerodowntime.dto.web.MessageDto;
 import static zerodowntime.generated.jooq.Tables.*;
 
@@ -26,35 +28,48 @@ public class MessageRepository extends BaseRepository {
     }
 
     public List<MessageDto> getUserTimelineMessages(int userId, int limit, int offset) {
-        return db.select(MESSAGE.fields())
+        var ownMessages = db.select(MESSAGE.fields())
                 .select(USERS.USERNAME, USERS.EMAIL)
                 .from(MESSAGE)
                 .join(USERS).on(MESSAGE.AUTHOR_ID.eq(USERS.USER_ID))
-                .where(MESSAGE.FLAGGED.eq(0))
-                .and(
-                        USERS.USER_ID.eq(userId)
-                                .or(USERS.USER_ID.in(
-                                        db.select(FOLLOWER.WHOM_ID)
-                                                .from(FOLLOWER)
-                                                .where(FOLLOWER.WHO_ID
-                                                        .eq(userId)))))
-                .orderBy(MESSAGE.PUB_DATE.desc())
+                .where(MESSAGE.AUTHOR_ID.eq(userId))
+                .and(MESSAGE.FLAGGED.eq(0));
+
+        var followedMessages = db.select(MESSAGE.fields())
+                .select(USERS.USERNAME, USERS.EMAIL)
+                .from(MESSAGE)
+                .join(USERS).on(MESSAGE.AUTHOR_ID.eq(USERS.USER_ID))
+                .where(MESSAGE.AUTHOR_ID.in(
+                        db.select(FOLLOWER.WHOM_ID)
+                                .from(FOLLOWER)
+                                .where(FOLLOWER.WHO_ID.eq(userId))))
+                .and(MESSAGE.FLAGGED.eq(0));
+
+        return db.select()
+                .from(ownMessages.unionAll(followedMessages))
+                .orderBy(DSL.field("pub_date").desc())
                 .limit(limit)
                 .offset(offset)
                 .fetchInto(MessageDto.class);
     }
 
     public int getUserTimelineCount(int userId) {
-        return db.selectCount()
+        int own = db.selectCount()
                 .from(MESSAGE)
-                .join(USERS).on(MESSAGE.AUTHOR_ID.eq(USERS.USER_ID))
-                .where(MESSAGE.FLAGGED.eq(0))
-                .and(USERS.USER_ID.eq(userId)
-                        .or(USERS.USER_ID.in(
-                                db.select(FOLLOWER.WHOM_ID)
-                                        .from(FOLLOWER)
-                                        .where(FOLLOWER.WHO_ID.eq(userId)))))
+                .where(MESSAGE.AUTHOR_ID.eq(userId))
+                .and(MESSAGE.FLAGGED.eq(0))
                 .fetchOne(0, int.class);
+
+        int followed = db.selectCount()
+                .from(MESSAGE)
+                .where(MESSAGE.AUTHOR_ID.in(
+                        db.select(FOLLOWER.WHOM_ID)
+                                .from(FOLLOWER)
+                                .where(FOLLOWER.WHO_ID.eq(userId))))
+                .and(MESSAGE.FLAGGED.eq(0))
+                .fetchOne(0, int.class);
+
+        return own + followed;
     }
 
     public List<MessageDto> getPublicTimelineMessages(int limit, int offset) {
@@ -70,10 +85,9 @@ public class MessageRepository extends BaseRepository {
     }
 
     public int getPublicTimelineCount() {
-        return db.selectCount()
-                .from(MESSAGE)
-                .where(MESSAGE.FLAGGED.eq(0))
-                .fetchOne(0, int.class);
+        return db.resultQuery("SELECT reltuples::bigint FROM pg_class WHERE relname = 'message'")
+                .fetchOne()
+                .get(0, Integer.class);
     }
 
     public List<MessageDto> getMessagesByUserId(int userId, int limit, int offset) {

--- a/minitwit-java/src/main/resources/schema.sql
+++ b/minitwit-java/src/main/resources/schema.sql
@@ -27,3 +27,4 @@ CREATE TABLE IF NOT EXISTS simulator_state (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON users (username);
 CREATE INDEX IF NOT EXISTS idx_message_flagged_pubdate ON message (flagged, pub_date DESC);
 CREATE INDEX IF NOT EXISTS idx_message_author_pubdate ON message (author_id, pub_date DESC);
+CREATE INDEX IF NOT EXISTS idx_follower_who_id ON follower(who_id); 

--- a/minitwit-java/src/main/resources/schema.sql
+++ b/minitwit-java/src/main/resources/schema.sql
@@ -28,3 +28,4 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON users (username);
 CREATE INDEX IF NOT EXISTS idx_message_flagged_pubdate ON message (flagged, pub_date DESC);
 CREATE INDEX IF NOT EXISTS idx_message_author_pubdate ON message (author_id, pub_date DESC);
 CREATE INDEX IF NOT EXISTS idx_follower_who_id ON follower(who_id); 
+CREATE INDEX IF NOT EXISTS idx_follower_whom_id ON follower(whom_id);


### PR DESCRIPTION
**Optimize user timeline query performance**
Rewrites the user timeline query from a single OR/IN subquery pattern to a UNION ALL approach, allowing Postgres to use idx_message_author_pubdate directly instead of scanning all 2.7M messages. Also adds a missing index on follower.who_id to speed up follower lookups