### PR TITLE
Add report scaffolding (Markdown + pandoc + LaTeX template)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,22 @@ vagrant.log
 
 # Ansible
 infra/ansible/.vault_pass
+
+# Report build artifacts
+report/report.pdf
+report/*.aux
+report/*.log
+report/*.out
+report/*.toc
+report/*.lof
+report/*.lot
+report/*.fls
+report/*.fdb_latexmk
+report/*.synctex.gz
+report/*.bbl
+report/*.blg
+report/*.run.xml
+
+# VS Code LaTeX Workshop
+report/*.synctex(busy)
+report/.texpadtmp/

--- a/report/CHEATSHEET.md
+++ b/report/CHEATSHEET.md
@@ -1,0 +1,194 @@
+# Markdown Cheat Sheet
+
+A quick reference for writing in `report.md`. Open the Markdown preview in
+VS Code with `Cmd+Shift+V` (or `Cmd+K V` to pin it side-by-side) to see
+your changes live as you type.
+
+## Headings (auto-numbered by pandoc)
+
+```markdown
+# Top-level section          → "1 Section"
+## Subsection                → "1.1 Subsection"
+### Sub-subsection           → "1.1.1 Sub-subsection"
+#### Deeper                  → "1.1.1.1 Deeper"
+```
+
+Don't write the numbers yourself — `--number-sections` does it for you.
+
+## Paragraphs and line breaks
+
+A blank line separates paragraphs. That's it.
+
+```markdown
+This is one paragraph. Linebreaks
+in the source don't matter.
+
+This is a new paragraph because of the blank line above.
+```
+
+## Page breaks
+
+Most of the time you don't need them — pandoc/LaTeX flows text across
+pages automatically. Only use this if you explicitly want a fresh page:
+
+```markdown
+\newpage
+```
+
+## Bold and italic
+
+```markdown
+**bold**
+*italic*
+***bold and italic***
+```
+
+## Lists
+
+```markdown
+- Bullet point
+- Another point
+  - Nested point (2-space indent)
+  - Another nested point
+
+1. Numbered item
+2. Next item
+3. Next item
+```
+
+## Code
+
+Inline code uses backticks: `` `like this` ``
+
+Code blocks with syntax highlighting:
+
+````markdown
+```bash
+docker compose up -d
+```
+
+```java
+public class UserRepository {
+    // ...
+}
+```
+
+```yaml
+services:
+  api:
+    image: minitwit-api
+```
+````
+
+## Links
+
+```markdown
+[Link text](https://pandoc.org/MANUAL.html)
+```
+
+## Images
+
+Place the file in `report/images/` and reference it:
+
+```markdown
+![Caption text](images/architecture.png)
+```
+
+## Tables
+
+```markdown
+| Component | Technology    |
+|-----------|---------------|
+| Frontend  | Svelte        |
+| Backend   | Java/Javalin  |
+| Database  | PostgreSQL    |
+```
+
+Alignment is controlled by colons in the separator row:
+
+```markdown
+| Left | Center | Right |
+|:-----|:------:|------:|
+| a    |   b    |     c |
+```
+
+## Quotes
+
+```markdown
+> A quoted block — useful for citing sources
+> or highlighting a key idea.
+```
+
+## Horizontal rule (visual divider)
+
+```markdown
+---
+```
+
+## Comments (won't appear in PDF)
+
+```markdown
+<!-- This text is invisible in the rendered output. -->
+```
+
+Useful for TODOs, notes to teammates, or reminders.
+
+## "Written by" convention
+
+Each section we write should have a byline directly under the heading:
+
+```markdown
+## System design
+
+*Written by Mathias Søgaard*
+
+The actual content of the section starts here...
+```
+
+## A complete example
+
+```markdown
+# Systems Perspective
+
+## System design
+
+*Written by Mathias Søgaard*
+
+Our MiniTwit application consists of a **web app** and an **API**.
+The web app is written in *Svelte* and communicates with a Java/Javalin
+backend over HTTP.
+
+Key components:
+
+- Frontend (Svelte SPA)
+- Backend (Java + Javalin)
+- Database (PostgreSQL)
+- Reverse proxy (nginx)
+
+The deployment runs on a 3-node Docker Swarm cluster on DigitalOcean.
+
+![Architecture overview](images/architecture.png)
+
+## Dependencies
+
+*Written by Corbijn*
+
+We rely on a small set of well-maintained libraries:
+
+| Library  | Purpose            |
+|----------|--------------------|
+| Javalin  | HTTP routing       |
+| HikariCP | Connection pooling |
+| Logback  | Logging            |
+```
+
+## Tips
+
+- **Use the live preview** — `Cmd+Shift+V` in VS Code shows you the
+  rendered output as you type. No need to build the PDF for every change.
+- **Keep source lines short** — wrap around 80 characters. It makes Git
+  diffs much cleaner when reviewing PRs.
+- **Don't write section numbers manually** — pandoc adds them.
+- **Don't worry about page breaks** — pandoc handles flow automatically.
+- **Build the PDF occasionally** — to sanity-check formatting, but day-to-day
+  the live preview is enough.

--- a/report/README.md
+++ b/report/README.md
@@ -4,7 +4,7 @@ This folder contains the project report for the DevOps, Software Evolution
 and Software Maintenance course (KSDSESM1KU).
 
 ## Formal Requirements for the report
-Your final report should be maximum 2500 words long, approx 9-10 pages. So, try to be brief and concise, but be sure to include all necessary information listed below. Note, images do not count as words.
+Your final report should be maximum 2500 words long, approx 5-6 pages. So, try to be brief and concise, but be sure to include all necessary information listed below. Note, images do not count as words.
 
 Make sure that you link all artifacts that you consider constitutional to your projects together with short descriptions of the linked artifacts from your reports, i.e., link all necessary repositories, issue trackers, monitoring/logging systems, etc.
 

--- a/report/README.md
+++ b/report/README.md
@@ -1,0 +1,155 @@
+# Report
+ 
+This folder contains the project report for the DevOps, Software Evolution
+and Software Maintenance course (KSDSESM1KU).
+ 
+## Structure
+ 
+```
+report/
+├── report.md          ← The actual report. Edit this.
+├── template.tex       ← LaTeX template (defines the title page layout)
+├── build-report.sh    ← Builds report.pdf from report.md
+├── CHEATSHEET.md      ← Markdown syntax reference
+├── images/            ← Diagrams, screenshots, charts
+└── README.md          ← This file
+```
+ 
+## Writing
+ 
+Edit `report.md` directly in VS Code. Open the Markdown preview side-by-side
+with `Cmd+Shift+V` (or `Cmd+K V` to keep it pinned) to see the rendered
+output as you type.
+ 
+Each section in `report.md` has a placeholder `*Written by [name]*` line —
+fill in your name when you take ownership of a section.
+ 
+See `CHEATSHEET.md` for a quick Markdown syntax reference.
+ 
+## Workflow
+ 
+We treat the report like code:
+ 
+1. Branch off `main`: `git checkout -b feature/report-<your-section>`
+2. Edit your section in `report.md`
+3. Commit and push
+4. Open a PR — at least one teammate reviews
+5. Merge to `main` when approved
+If two people are editing different sections, no conflicts. If two people
+edit the same section, resolve like any other Git merge conflict.
+ 
+## Building the PDF
+ 
+```bash
+cd report
+./build-report.sh
+```
+ 
+This produces `report.pdf` in the same folder.
+ 
+`report.pdf` is **not** committed to Git — it is a build artifact, like
+binaries. It is added to `.gitignore`.
+ 
+## Requirements
+ 
+You only need to build the PDF locally if you want to preview the final
+formatting. Day-to-day writing only needs the Markdown preview in VS Code
+(`Cmd+Shift+V`) — you can skip all of the LaTeX setup if you only plan
+to write content.
+ 
+To build the PDF you need pandoc and a LaTeX distribution.
+ 
+### macOS
+ 
+```bash
+brew install pandoc
+brew install --cask basictex
+```
+ 
+After installing BasicTeX, add the LaTeX binaries to your PATH so `xelatex`
+can be found:
+ 
+```bash
+echo 'export PATH="/Library/TeX/texbin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+```
+ 
+Verify:
+ 
+```bash
+which xelatex   # should print /Library/TeX/texbin/xelatex
+```
+ 
+Install the LaTeX packages required by our template (BasicTeX is minimal
+and ships with very few packages):
+ 
+```bash
+sudo tlmgr update --self
+sudo tlmgr install collection-fontsrecommended \
+                   csquotes microtype enumitem fvextra framed bookmark \
+                   parskip setspace multirow titling upquote \
+                   xcolor booktabs tabularx titlesec fancyhdr mdwtools
+```
+ 
+### Ubuntu/Linux (e.g. inside the UTM VM)
+ 
+```bash
+sudo apt install pandoc \
+                 texlive-xetex \
+                 texlive-fonts-recommended \
+                 texlive-latex-extra \
+                 texlive-luatex
+```
+ 
+`texlive-latex-extra` covers most of what BasicTeX needs `tlmgr` for on
+macOS (csquotes, microtype, enumitem, fvextra, etc.).
+ 
+### Windows
+ 
+1. Download and install pandoc from https://pandoc.org/installing.html
+2. Download and install MiKTeX from https://miktex.org/download
+3. During MiKTeX install, set "Install missing packages on the fly" to *Yes*
+To run `build-report.sh` on Windows, use **Git Bash** (comes with Git for
+Windows) or **WSL**. PowerShell will not run the script directly.
+ 
+```bash
+cd report
+./build-report.sh
+```
+ 
+MiKTeX will automatically download missing LaTeX packages on the first
+build — just click "Install" if a popup appears.
+ 
+### Troubleshooting
+ 
+If `./build-report.sh` fails with a missing LaTeX package error like
+`! LaTeX Error: File 'xxx.sty' not found`, install it with:
+ 
+```bash
+sudo tlmgr install <package-name-from-error>
+```
+ 
+If you get `xelatex: createProcess: find_executable: failed`, your PATH
+does not include the LaTeX binaries — see the macOS PATH step above.
+ 
+If you get a `\@parboxrestore has changed` warning, ignore it — it's
+harmless and the PDF still builds correctly.
+ 
+## Markdown crash course
+ 
+For a full syntax reference, see `CHEATSHEET.md`. Here's the bare minimum:
+ 
+| What you want         | How to write it                          |
+|-----------------------|------------------------------------------|
+| Heading level 1       | `# Heading`                              |
+| Heading level 2       | `## Heading`                             |
+| Bold                  | `**bold**`                               |
+| Italic                | `*italic*`                               |
+| Inline code           | `` `code` ``                             |
+| Code block            | ` ```language ... ``` `                  |
+| Bullet list           | `- item`                                 |
+| Numbered list         | `1. item`                                |
+| Link                  | `[text](https://url)`                    |
+| Image                 | `![alt text](images/file.png)`           |
+| Table                 | See `CHEATSHEET.md` for table syntax.    |
+| Page break (PDF)      | `\newpage` on its own line               |

--- a/report/README.md
+++ b/report/README.md
@@ -2,7 +2,14 @@
  
 This folder contains the project report for the DevOps, Software Evolution
 and Software Maintenance course (KSDSESM1KU).
- 
+
+## Formal Requirements for the report
+Your final report should be maximum 2500 words long, approx 9-10 pages. So, try to be brief and concise, but be sure to include all necessary information listed below. Note, images do not count as words.
+
+Make sure that you link all artifacts that you consider constitutional to your projects together with short descriptions of the linked artifacts from your reports, i.e., link all necessary repositories, issue trackers, monitoring/logging systems, etc.
+
+Since this is a group project and the report is written by a group make sure to indicate for each section the respective author(s).
+
 ## Structure
  
 ```

--- a/report/build-report.sh
+++ b/report/build-report.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# build-report.sh — converts report.md to a PDF using pandoc.
+#
+# Usage: ./build-report.sh
+# Output: report.pdf in the current directory.
+#
+# Works on macOS, Linux, and Windows (via Git Bash or WSL).
+# See README.md for installation requirements.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+INPUT="report.md"
+OUTPUT="report.pdf"
+TEMPLATE="./template.tex"
+
+if ! command -v pandoc >/dev/null 2>&1; then
+    echo "Error: pandoc is not installed. See report/README.md."
+    echo "  macOS:    brew install pandoc"
+    echo "  Ubuntu:   sudo apt install pandoc"
+    echo "  Windows:  https://pandoc.org/installing.html"
+    exit 1
+fi
+
+if ! command -v xelatex >/dev/null 2>&1; then
+    echo "Error: xelatex is not installed or not on PATH."
+    echo "See report/README.md for installation and PATH setup."
+    exit 1
+fi
+
+echo "Building $OUTPUT from $INPUT..."
+
+pandoc "$INPUT" \
+    --output="$OUTPUT" \
+    --template="$TEMPLATE" \
+    --number-sections \
+    --pdf-engine=xelatex \
+    --syntax-highlighting=tango
+
+echo "Done. Output: $(pwd)/$OUTPUT"

--- a/report/report.md
+++ b/report/report.md
@@ -16,7 +16,7 @@ students:
 ---
  
 <!--
-Your final report should be maximum 2500 words long, approx 9-10 pages. So, try to be brief and concise, but be sure to include all necessary information listed below. Note, images do not count as words.
+Your final report should be maximum 2500 words long, approx 5-6. So, try to be brief and concise, but be sure to include all necessary information listed below. Note, images do not count as words.
 
 Make sure that you link all artifacts that you consider constitutional to your projects together with short descriptions of the linked artifacts from your reports, i.e., link all necessary repositories, issue trackers, monitoring/logging systems, etc.
 

--- a/report/report.md
+++ b/report/report.md
@@ -16,48 +16,57 @@ students:
 ---
  
 <!--
-Outline will be added next week.
-The section below is an example showing how a section is structured.
+Your final report should be maximum 2500 words long, approx 9-10 pages. So, try to be brief and concise, but be sure to include all necessary information listed below. Note, images do not count as words.
+
+Make sure that you link all artifacts that you consider constitutional to your projects together with short descriptions of the linked artifacts from your reports, i.e., link all necessary repositories, issue trackers, monitoring/logging systems, etc.
+
+Since this is a group project and the report is written by a group make sure to indicate for each section the respective author(s).
+
 Build:  ./build-report.sh
 -->
  
 # Systems Perspective
 
-## System design
-
 *Written by Insert Name*
 
-Our MiniTwit application consists of a **web app** and an **API**.
-The web app is written in *Svelte* and communicates with a Java/Javalin
-backend over HTTP.
+A description and illustration of the:
 
-Key components:
-
-- Frontend (Svelte SPA)
-- Backend (Java + Javalin)
-- Database (PostgreSQL)
-- Reverse proxy (nginx)
-
-The deployment runs on a 3-node Docker Swarm cluster on DigitalOcean.
-
-## Dependencies
-
-*Written by Insert Name*
-
-We rely on a small set of well-maintained libraries:
-
-| Library  | Purpose                  |
-|----------|--------------------------|
-| Javalin  | HTTP routing             |
-| HikariCP | Connection pooling       |
-| Logback  | Logging                  |
+- Design and architecture of your ITU-MiniTwit systems.
+- All dependencies of your ITU-MiniTwit systems on all levels of abstraction and development stages. That is, list and briefly describe all technologies and tools you applied and depend on.
+- Describe the current state of your systems, for example using results of static analysis and quality assessments.
 
 \newpage
 
 # Process Perspective
 
-## CI/CD chains
+*Written by Insert Name*
+
+This perspective should clarify how code or other artifacts come from idea into the running system and everything that happens on the way.
+
+In particular, the following descriptions should be included:
+
+- A complete description and illustration of stages and tools included in the CI/CD pipelines, including deployment and release of your systems.
+- How do you monitor your systems and what precisely do you monitor?
+- What do you log in your systems and how do you aggregate logs?
+- Brief description of how you security hardened your systems.
+- How do you handle availability and scaling in your systems?
+
+# Reflection Perspective
 
 *Written by Insert Name*
 
-Our pipeline triggers on every push to `main`...
+Describe the biggest issues, how you solved them, and which are major lessons learned with regards to:
+
+- evolution and refactoring
+- operation, and
+- maintenance
+
+of your ITU-MiniTwit systems. Link back to respective commit messages, issues, tickets, etc. to illustrate these.
+
+Also reflect and describe what was the "DevOps" style of your work. For example, what did you do differently to previous development projects and how did it work?
+
+# Use of Generative AI
+
+*Written by Claude*
+
+ITU's rules on the use of generative AI apply for this report too. They are described here and in detail here. Please follow them. For your report that means that you have to state which generative AI tools have been used for which task(s) in your projects. Additionally, describe how generative AI tools have been used and briefly reflect and discuss how they supported or hindered your work process.

--- a/report/report.md
+++ b/report/report.md
@@ -1,0 +1,63 @@
+---
+title: "DevOps, Software Evolution & Software Maintenance"
+course: "KSDSESM1KU"
+date: "May 2026"
+students:
+  - name: "Corbijn Bulsink"
+    email: "jbul@itu.dk"
+  - name: "Kasper Larsson"
+    email: "kasla@itu.dk"
+  - name: "Ymir Arnarson"
+    email: "ymar@itu.dk"
+  - name: "Magnus Bergstedt"
+    email: "magnb@itu.dk"
+  - name: "Mathias Søgaard"
+    email: "msoeg@itu.dk"
+---
+ 
+<!--
+Outline will be added next week.
+The section below is an example showing how a section is structured.
+Build:  ./build-report.sh
+-->
+ 
+# Systems Perspective
+
+## System design
+
+*Written by Insert Name*
+
+Our MiniTwit application consists of a **web app** and an **API**.
+The web app is written in *Svelte* and communicates with a Java/Javalin
+backend over HTTP.
+
+Key components:
+
+- Frontend (Svelte SPA)
+- Backend (Java + Javalin)
+- Database (PostgreSQL)
+- Reverse proxy (nginx)
+
+The deployment runs on a 3-node Docker Swarm cluster on DigitalOcean.
+
+## Dependencies
+
+*Written by Insert Name*
+
+We rely on a small set of well-maintained libraries:
+
+| Library  | Purpose                  |
+|----------|--------------------------|
+| Javalin  | HTTP routing             |
+| HikariCP | Connection pooling       |
+| Logback  | Logging                  |
+
+\newpage
+
+# Process Perspective
+
+## CI/CD chains
+
+*Written by Insert Name*
+
+Our pipeline triggers on every push to `main`...

--- a/report/template.tex
+++ b/report/template.tex
@@ -1,0 +1,215 @@
+\documentclass[11pt,a4paper]{article}
+ 
+% =========================================================
+%  PACKAGES
+% =========================================================
+ 
+% --- Layout ---
+\usepackage[margin=2.5cm]{geometry}
+\usepackage{fancyhdr}
+\usepackage{titlesec}
+\usepackage{titling}
+\usepackage{setspace}
+\usepackage{parskip}
+ 
+% --- Fonts and typography ---
+\usepackage{fontspec}
+\usepackage{microtype}
+\usepackage{upquote}
+\usepackage{csquotes}
+ 
+% --- Math ---
+\usepackage{amsmath}
+\usepackage{amssymb}
+ 
+% --- Color and graphics ---
+\usepackage[table]{xcolor}
+\usepackage{graphicx}
+ 
+% --- Tables ---
+\usepackage{longtable}
+\usepackage{booktabs}
+\usepackage{array}
+\usepackage{tabularx}
+\usepackage{multirow}
+ 
+% --- Lists ---
+\usepackage{enumitem}
+ 
+% --- Code blocks ---
+\usepackage{fvextra}
+\usepackage{framed}
+ 
+% --- Hyperlinks (load late) ---
+\usepackage{hyperref}
+\usepackage{bookmark}
+ 
+% =========================================================
+%  PANDOC COMPATIBILITY MACROS
+% =========================================================
+ 
+% Pandoc syntax highlighting (only included when needed)
+$if(highlighting-macros)$
+$highlighting-macros$
+$endif$
+ 
+% Tight list macro (used by bullet/numbered lists)
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+ 
+% Pandoc's bounded image wrapper
+\providecommand{\pandocbounded}[1]{#1}
+ 
+% Real number (used in some pandoc width calculations)
+\providecommand{\real}[1]{#1}
+ 
+% Pandoc passes through raw blocks; ensure they don't break
+\providecommand{\passthrough}[1]{#1}
+ 
+% Make sure section numbering depth is sufficient
+\setcounter{secnumdepth}{5}
+\setcounter{tocdepth}{3}
+ 
+% Counter fallback (some pandoc tables reference 'none')
+\makeatletter
+\@ifundefined{c@none}{\newcounter{none}}{}
+\makeatother
+ 
+% Make verbatim/code blocks break long lines instead of overflowing
+\DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,commandchars=\\\{\}}
+ 
+% =========================================================
+%  FONTS
+% =========================================================
+ 
+\setmainfont{Helvetica Neue}
+\setmonofont{Menlo}[Scale=0.9]
+ 
+% =========================================================
+%  COLORS
+% =========================================================
+ 
+\definecolor{linecolor}{HTML}{CCCCCC}
+\definecolor{headerbg}{HTML}{F2F2F2}
+\definecolor{codebg}{HTML}{F7F7F7}
+\definecolor{linkcolor}{HTML}{0066CC}
+ 
+% =========================================================
+%  HYPERLINKS
+% =========================================================
+ 
+\hypersetup{
+    colorlinks=true,
+    linkcolor=linkcolor,
+    urlcolor=linkcolor,
+    citecolor=linkcolor,
+    pdftitle={$title$},
+    pdfauthor={$for(students)$$students.name$$sep$, $endfor$},
+    bookmarksnumbered=true,
+    bookmarksopen=true
+}
+ 
+% =========================================================
+%  SECTION FORMATTING
+% =========================================================
+ 
+\titleformat{\section}{\Large\bfseries}{\thesection}{1em}{}
+\titleformat{\subsection}{\large\bfseries}{\thesubsection}{1em}{}
+\titleformat{\subsubsection}{\normalsize\bfseries}{\thesubsubsection}{1em}{}
+ 
+% Spacing around sections
+\titlespacing*{\section}{0pt}{1.5em}{0.8em}
+\titlespacing*{\subsection}{0pt}{1.2em}{0.6em}
+\titlespacing*{\subsubsection}{0pt}{1em}{0.5em}
+ 
+% Start each top-level section on a new page (uncomment to enable)
+% \newcommand{\sectionbreak}{\clearpage}
+ 
+% =========================================================
+%  PAGE NUMBERING & HEADERS
+% =========================================================
+ 
+\pagestyle{fancy}
+\fancyhf{}
+\fancyfoot[C]{\thepage}
+\renewcommand{\headrulewidth}{0pt}
+\renewcommand{\footrulewidth}{0pt}
+ 
+% =========================================================
+%  LIST SPACING
+% =========================================================
+ 
+\setlist[itemize]{itemsep=2pt, topsep=4pt}
+\setlist[enumerate]{itemsep=2pt, topsep=4pt}
+ 
+% =========================================================
+%  IMAGE / FIGURE DEFAULTS
+% =========================================================
+ 
+% Allow images to scale to text width if they are too wide
+\setkeys{Gin}{width=\linewidth, keepaspectratio}
+ 
+% =========================================================
+%  PARAGRAPH STYLING
+% =========================================================
+ 
+\setlength{\parskip}{0.5em}
+\setlength{\parindent}{0pt}
+ 
+% =========================================================
+%  DOCUMENT
+% =========================================================
+ 
+\begin{document}
+ 
+% =========================================================
+%  TITLE PAGE
+% =========================================================
+\begin{titlepage}
+\thispagestyle{empty}
+\vspace*{2cm}
+ 
+\noindent
+{\Huge\bfseries $title$ \par}
+ 
+\vspace{0.3cm}
+\noindent\textcolor{linecolor}{\rule{\textwidth}{0.5pt}}
+ 
+\vspace{1cm}
+\noindent{\large\bfseries Course code: $course$ \par}
+ 
+\vspace{0.8cm}
+\noindent{\large\bfseries $date$ \par}
+ 
+\vspace{1.5cm}
+\noindent{\bfseries\MakeUppercase{Exam Assignment By}\par}
+ 
+\vspace{0.5cm}
+\noindent
+\renewcommand{\arraystretch}{1.4}
+\begin{tabularx}{\textwidth}{|>{\centering\arraybackslash}X|>{\centering\arraybackslash}X|}
+\hline
+\rowcolor{headerbg}
+\textbf{Student} & \textbf{Email} \\
+\hline
+$for(students)$
+$students.name$ & $students.email$ \\
+\hline
+$endfor$
+\end{tabularx}
+ 
+\vfill
+\end{titlepage}
+ 
+% =========================================================
+%  TABLE OF CONTENTS
+% =========================================================
+\tableofcontents
+\newpage
+ 
+% =========================================================
+%  BODY
+% =========================================================
+$body$
+ 
+\end{document}


### PR DESCRIPTION
## Note

From Fridays slides, I saw that he wanted us to use --number-sections and pandoc in the report. I took a look at it, and it shows that we can use our Git Repo to build the project, which is nice!. Next week we will have the outline, and then I will update the whole thing, and then we just have to delegate sections. 

## What

Adds the scaffolding for our project report:

- `report/report.md` — the actual report (Markdown)
- `report/template.tex` — custom LaTeX template for a polished title page
- `report/build-report.sh` — one-command PDF build via pandoc
- `report/README.md` — workflow + installation guide for all platforms
- `report/CHEATSHEET.md` — Markdown syntax reference

## Why

Treats the report like code: versioned in Git, reviewed via PRs, 
consistent formatting via a single template — instead of a shared 
Google Doc.

## How to use

1. Pull `main` after this is merged
2. Create your own branch: `git checkout -b feature/report-<your-section>`
3. Edit `report.md`
4. Open a PR

You don't need to install anything to write - just use VS Code's Markdown
preview (`Cmd+Shift+V`). LaTeX is only required if you want to build the
PDF locally. See `report/README.md` for setup details.